### PR TITLE
fix(springboot): change return type in example changes

### DIFF
--- a/ru.werf.io/guides/java_springboot/100_basic/10_build.md
+++ b/ru.werf.io/guides/java_springboot/100_basic/10_build.md
@@ -176,7 +176,7 @@ _Вы также можете заметить, что и вызов `werf run` 
 {% raw %}
 ```
     @GetMapping("/labels")
-    public List<Labels> labels() {
+    public String labels() {
         return "Our changes";
     }
 ```

--- a/werf.io/guides/java_springboot/100_basic/10_build.md
+++ b/werf.io/guides/java_springboot/100_basic/10_build.md
@@ -178,7 +178,7 @@ As you might guess, we are going to continually update our application. Let's se
 {% raw %}
 ```
     @GetMapping("/labels")
-    public List<Labels> labels() {
+    public String labels() {
         return "Our changes";
     }
 ```


### PR DESCRIPTION
Change return type from `List<Labels>` to `String` in a springboot guide.