### PR TITLE
fix(ci): cleanup container registry workflow failed

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -25,3 +25,4 @@ jobs:
         uses: werf/actions/cleanup@v1.2
         env:
           WERF_LOG_VERBOSE: "on"
+          WERF_REPO_GITHUB_TOKEN: ${{ secrets.REGISTRY_CLEANUP_TOKEN }}


### PR DESCRIPTION
```
Error: unable to remove repo image meta-fb496116_7b3e318b1f7027af17dacc690389a330fbd99dac_813a1fb8b8a06897d727c82b736a2c9dc5e708dd6c49504adf6fe24a-1628744443760: gitHub packages forbidden: GET https://api.github.com/orgs/werf/packages/container/werfio-guides/versions?page=REDACTED&per_page=REDACTED: unexpected status code 403 Forbidden (body: {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-an-organization"})

You should specify a token with delete:packages and read:packages scopes to remove package versions.
Check --repo-github-token option.
Be aware that the token provided to GitHub Actions workflow is not enough to remove package versions.
Read more details here https://werf.io/documentation/v1.2/advanced/supported_container_registries.html#github-packages
```